### PR TITLE
團契資料維護按下刪除後，無法刪除，跳出錯誤

### DIFF
--- a/app/Repositories/fellowshipRepository.php
+++ b/app/Repositories/fellowshipRepository.php
@@ -134,15 +134,15 @@
 
                 // \Debugbar::info($id);
                 $objMeegingInfo = new \Models\MeetingInfo;
-                if (count($this->dtFellowship->find($id)) > 0
-                    && count($objMeegingInfo::where('fellowship_id', '=', $id)) > 0) {
+                if (!empty($this->dtFellowship->find($id))
+                    && !empty($objMeegingInfo::where('fellowship_id', '=', $id)) ) {
                     DB::connection()->getPdo()->beginTransaction();
 
                     $this->dtFellowship->find($id)->delete();
                     $objMeegingInfo::where('fellowship_id', '=', $id)->delete();
                     /*\Debugbar::info(count($this->dtFellowship->find($id)));
                     \Debugbar::info(count($objMeegingInfo::where('fellowship_id','=',$id)));*/
-                    if (count($this->dtFellowship_d->where('fellowship_id', '=', $id)) > 0) {
+                    if (!empty($this->dtFellowship_d->where('fellowship_id', '=', $id)) ) {
 
                         /*
                         * 團契照片名稱都是該資料烈的id，所以要取出刪除照片名稱就是取出ＩＤ


### PR DESCRIPTION
原來寫法會導致再刪除時發生錯誤，因為根本沒有該路徑，所以就會跳出錯誤，將刪除實體路徑的程式碼拿掉，未來的圖片檔案都是存在在AWS上面